### PR TITLE
MODLD-630: Do not set RESOURCE_PREFERRED flag when resource is created from Bib

### DIFF
--- a/src/main/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/ConceptFormMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/ConceptFormMapper.java
@@ -7,7 +7,6 @@ import static org.folio.ld.dictionary.PredicateDictionary.SUBJECT;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
 import static org.folio.ld.dictionary.PropertyDictionary.LINK;
 import static org.folio.ld.dictionary.PropertyDictionary.NAME;
-import static org.folio.ld.dictionary.PropertyDictionary.RESOURCE_PREFERRED;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.CONCEPT;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.FORM;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.IDENTIFIER;
@@ -94,8 +93,7 @@ public class ConceptFormMapper extends AbstractBookMapper {
       LABEL.getValue(), List.of(CODE_TO_LCCN_MAP.get(code))
     ), Collections.emptyMap());
     var form = createResource(Set.of(FORM), Map.of(
-      NAME.getValue(), List.of(CODE_TO_LABEL_MAP.get(code)),
-      RESOURCE_PREFERRED.getValue(), List.of("true")
+      NAME.getValue(), List.of(CODE_TO_LABEL_MAP.get(code))
     ), Map.of(MAP, lccn));
     var conceptForm = createResource(Set.of(CONCEPT, FORM), Map.of(
       NAME.getValue(), List.of(CODE_TO_LABEL_MAP.get(code))

--- a/src/test/java/org/folio/marc4ld/mapper/field008/Marc2LdConceptFormIT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field008/Marc2LdConceptFormIT.java
@@ -120,25 +120,13 @@ class Marc2LdConceptFormIT extends Marc2LdTestBase {
     return focusEdges -> {
       assertThat(focusEdges).hasSize(4);
       validateEdge(focusEdges.getFirst(), predicate, List.of(FORM),
-        Map.of(
-          "http://bibfra.me/vocab/lite/name", List.of("Catalogs"),
-          "http://library.link/vocab/resourcePreferred", List.of("true")
-        ), "Catalogs");
+        Map.of("http://bibfra.me/vocab/lite/name", List.of("Catalogs")), "Catalogs");
       validateEdge(focusEdges.get(1), predicate, List.of(FORM),
-        Map.of(
-          "http://bibfra.me/vocab/lite/name", List.of("Indexes"),
-          "http://library.link/vocab/resourcePreferred", List.of("true")
-        ), "Indexes");
+        Map.of("http://bibfra.me/vocab/lite/name", List.of("Indexes")), "Indexes");
       validateEdge(focusEdges.get(2), predicate, List.of(FORM),
-        Map.of(
-          "http://bibfra.me/vocab/lite/name", List.of("Calendars"),
-          "http://library.link/vocab/resourcePreferred", List.of("true")
-        ), "Calendars");
+        Map.of("http://bibfra.me/vocab/lite/name", List.of("Calendars")), "Calendars");
       validateEdge(focusEdges.get(3), predicate, List.of(FORM),
-        Map.of(
-          "http://bibfra.me/vocab/lite/name", List.of("Comics (Graphic works)"),
-          "http://library.link/vocab/resourcePreferred", List.of("true")
-        ), "Comics (Graphic works)");
+        Map.of("http://bibfra.me/vocab/lite/name", List.of("Comics (Graphic works)")), "Comics (Graphic works)");
     };
   }
 }


### PR DESCRIPTION
Per the decision we made during the beginning of this project,`"http://library.link/vocab/resourcePreferred":  true` property should be added to a resource node only when that resource is created out of a MARC authority record.

In this case, this property was added to a node created out of Bib MARC records. This PR fixes the problem.