### PR TITLE
UILD-557: Remove extent literal property

### DIFF
--- a/src/main/resources/marc4ld.yml
+++ b/src/main/resources/marc4ld.yml
@@ -499,7 +499,6 @@ bibFieldRules:
   300:
     - types: INSTANCE
       subfields:
-        a: EXTENT
         b: PHYSICAL_DESCRIPTION
         c: DIMENSIONS
         e: ACCOMPANYING_MATERIAL

--- a/src/test/java/org/folio/marc4ld/mapper/MarcBib2LdMapperIT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/MarcBib2LdMapperIT.java
@@ -44,7 +44,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.EAN_VALUE;
 import static org.folio.ld.dictionary.PropertyDictionary.EDITION;
 import static org.folio.ld.dictionary.PropertyDictionary.ENTITY_AND_ATTRIBUTE_INFORMATION;
 import static org.folio.ld.dictionary.PropertyDictionary.EXHIBITIONS_NOTE;
-import static org.folio.ld.dictionary.PropertyDictionary.EXTENT;
 import static org.folio.ld.dictionary.PropertyDictionary.FORMER_TITLE_NOTE;
 import static org.folio.ld.dictionary.PropertyDictionary.FUNDING_INFORMATION;
 import static org.folio.ld.dictionary.PropertyDictionary.GEOGRAPHIC_COVERAGE;
@@ -307,7 +306,7 @@ class MarcBib2LdMapperIT extends Marc2LdTestBase {
   private void validateInstance(Resource resource) {
     validateId(resource);
     assertThat(resource.getLabel()).isEqualTo("MainTitle SubTitle");
-    assertThat(resource.getDoc()).hasSize(35);
+    assertThat(resource.getDoc()).hasSize(34);
     validateInstanceNotes(resource);
     assertThat(resource.getDoc().has(EDITION.getValue())).isTrue();
     assertThat(resource.getDoc().get(EDITION.getValue())).hasSize(1);
@@ -317,9 +316,6 @@ class MarcBib2LdMapperIT extends Marc2LdTestBase {
     assertThat(resource.getDoc().get(STATEMENT_OF_RESPONSIBILITY.getValue())).hasSize(1);
     assertThat(resource.getDoc().get(STATEMENT_OF_RESPONSIBILITY.getValue()).get(0).asText())
       .isEqualTo("Statement Of Responsibility");
-    assertThat(resource.getDoc().has(EXTENT.getValue())).isTrue();
-    assertThat(resource.getDoc().get(EXTENT.getValue())).hasSize(1);
-    assertThat(resource.getDoc().get(EXTENT.getValue()).get(0).asText()).isEqualTo("extent");
     assertThat(resource.getDoc().has(DIMENSIONS.getValue())).isTrue();
     assertThat(resource.getDoc().get(DIMENSIONS.getValue())).hasSize(1);
     assertThat(resource.getDoc().get(DIMENSIONS.getValue()).get(0).asText()).isEqualTo("dimensions");

--- a/src/test/java/org/folio/marc4ld/mapper/field300/Ld2Marc300IT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field300/Ld2Marc300IT.java
@@ -64,7 +64,6 @@ class Ld2Marc300IT {
     ).setLabel("extent2 unit_type2 unit_size2");
     return MonographTestUtil.createResource(
       Map.of(
-        PropertyDictionary.EXTENT, List.of("extent"),
         DIMENSIONS, List.of("dimension1", "dimension2"),
         PHYSICAL_DESCRIPTION, List.of("physical_description1", "physical_description2"),
         ACCOMPANYING_MATERIAL, List.of("accompanying_material1", "accompanying_material2")

--- a/src/test/java/org/folio/marc4ld/mapper/field300/MarcToLd300IT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field300/MarcToLd300IT.java
@@ -44,7 +44,6 @@ class MarcToLd300IT extends Marc2LdTestBase {
     assertThat(result)
       .satisfies(r -> validateResource(r, List.of(ResourceTypeDictionary.INSTANCE),
         Map.of(
-          PropertyDictionary.EXTENT.getValue(), List.of("extent"),
           DIMENSIONS.getValue(), List.of("dimensions"),
           PHYSICAL_DESCRIPTION.getValue(), List.of("physical_description"),
           ACCOMPANYING_MATERIAL.getValue(), List.of("accompanying_material")

--- a/src/test/java/org/folio/marc4ld/mapper/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/marc4ld/mapper/test/MonographTestUtil.java
@@ -57,7 +57,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.EDITION_NUMBER;
 import static org.folio.ld.dictionary.PropertyDictionary.ENTITY_AND_ATTRIBUTE_INFORMATION;
 import static org.folio.ld.dictionary.PropertyDictionary.EQUIVALENT;
 import static org.folio.ld.dictionary.PropertyDictionary.EXHIBITIONS_NOTE;
-import static org.folio.ld.dictionary.PropertyDictionary.EXTENT;
 import static org.folio.ld.dictionary.PropertyDictionary.FIELD_LINK;
 import static org.folio.ld.dictionary.PropertyDictionary.FORMER_TITLE_NOTE;
 import static org.folio.ld.dictionary.PropertyDictionary.FORM_SUBDIVISION;
@@ -215,7 +214,6 @@ public class MonographTestUtil {
       .setSrsId("43d58061-decf-4d74-9747-0e1c368e861b");
     return createResource(
       Map.ofEntries(
-        entry(EXTENT, List.of("extent")),
         entry(DIMENSIONS, List.of("dimensions"))
       ),
       Set.of(INSTANCE),
@@ -414,7 +412,6 @@ public class MonographTestUtil {
       .setSrsId("43d58061-decf-4d74-9747-0e1c368e861b");
     return createResource(
       Map.ofEntries(
-        entry(EXTENT, List.of("extent")),
         entry(DIMENSIONS, List.of("dimensions")),
         entry(EDITION, List.of("Edition Statement Edition statement2")),
         entry(PROJECTED_PROVISION_DATE, List.of("projectedProvisionDate")),


### PR DESCRIPTION
Removing `extent` literal property derived from MARC, leaving in `extent` object predicate. See https://github.com/folio-org/ui-linked-data/pull/188