### PR TITLE
MODLD-807: Update Marc mappings to be consistent with the resources created via Linked Data UI

### DIFF
--- a/src/main/resources/marc4ld.yml
+++ b/src/main/resources/marc4ld.yml
@@ -627,16 +627,20 @@ bibFieldRules:
           predicate: IS_PART_OF
           subfields:
             a: NAME
+            x: ISSN
           ld2marcCondition:
             skip: true
           edges:
+            - types: ID_ISSN, IDENTIFIER
+              predicate: MAP
+              subfields:
+                x: NAME
             - types: INSTANCE, SERIES
               parent: SERIES
               predicate: INSTANTIATES
               subfields:
                 a: NAME
-              ld2marcCondition:
-                skip: true
+                x: ISSN
               edges:
                 - types: ID_ISSN, IDENTIFIER
                   predicate: MAP
@@ -647,7 +651,6 @@ bibFieldRules:
                   marc2ldCondition:
                     fieldsAllOf:
                       x: presented
-
   500:
     - types: INSTANCE
       subfields:

--- a/src/test/java/org/folio/marc4ld/mapper/field490/Marc2Ld490IT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field490/Marc2Ld490IT.java
@@ -63,9 +63,9 @@ class Marc2Ld490IT extends Marc2LdTestBase {
       .satisfies(this::validateWorkSeries)
       .extracting(workSeries ->
         getFirstOutgoingEdge(workSeries, withPredicateUri("http://bibfra.me/vocab/relation/isPartOf")))
-      .satisfies(this::validateSeries)
+      .satisfies(this::validateSeriesWithoutIssn)
       .extracting(series -> getFirstIncomingEdge(series, withPredicateUri("http://bibfra.me/vocab/lite/instantiates")))
-      .satisfies(this::validateInstanceSeries)
+      .satisfies(this::validateInstanceSeriesWithoutIssn)
       .extracting(ResourceEdge::getSource)
       .satisfies(this::hasNoIssnIdentifier);
   }
@@ -87,10 +87,31 @@ class Marc2Ld490IT extends Marc2LdTestBase {
     validateEdge(series, IS_PART_OF, List.of(SERIES),
       Map.of(
         "http://bibfra.me/vocab/lite/label", List.of("name"),
-        "http://bibfra.me/vocab/lite/name", List.of("name")), "name");
+        "http://bibfra.me/vocab/lite/name", List.of("name"),
+        "http://bibfra.me/vocab/marc/issn", List.of("issn")
+      ), "name");
+
+    var issnEdge = getFirstOutgoingEdge(series.getTarget(), withPredicateUri("http://library.link/vocab/map"));
+    validateIssnIdentifier(issnEdge);
+  }
+
+  private void validateSeriesWithoutIssn(ResourceEdge series) {
+    validateEdge(series, IS_PART_OF, List.of(SERIES),
+      Map.of(
+        "http://bibfra.me/vocab/lite/label", List.of("name"),
+        "http://bibfra.me/vocab/lite/name", List.of("name")
+      ), "name");
   }
 
   private void validateInstanceSeries(ResourceEdge instanceSeries) {
+    validateEdgeWithSource(instanceSeries, INSTANTIATES, List.of(INSTANCE, SERIES),
+      Map.of(
+        "http://bibfra.me/vocab/lite/label", List.of("name"),
+        "http://bibfra.me/vocab/lite/name", List.of("name"),
+        "http://bibfra.me/vocab/marc/issn", List.of("issn")), "name");
+  }
+
+  private void validateInstanceSeriesWithoutIssn(ResourceEdge instanceSeries) {
     validateEdgeWithSource(instanceSeries, INSTANTIATES, List.of(INSTANCE, SERIES),
       Map.of(
         "http://bibfra.me/vocab/lite/label", List.of("name"),


### PR DESCRIPTION
The Graph resources created via DTO (mod-linked-data) and via MARC mappings of field 490 is inconsistent.
This PR aims to make them consistent.

Here is the mod-linked-data PR that create the graph resources: https://github.com/folio-org/mod-linked-data/pull/249 