### PR TITLE
MODLD-829: (Code cleanup) - Create separate class for mapping updated date (005)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Conversion rules from Graph to MARC - WORK type defines Leader Field [MODLD-806](https://folio-org.atlassian.net/browse/MODLD-806)
 - Graph to MARC logic when Books and Serials fields co-exist (008/18-34) [MODLD-812](https://folio-org.atlassian.net/browse/MODLD-812)
 - Convert MARC 040 to Graph and vice-versa [MODLD-784](https://folio-org.atlassian.net/browse/MODLD-784)
+- Code cleanup - Create separate class for mapping updated date (005) [MODLD-829](https://folio-org.atlassian.net/browse/MODLD-829)
 
 ## 1.0.3 (04-09-2025)
 - Geographic coverage: single "geographicCoverage" edge is created for Work which contains 043 with multiple $a fields [MODLD-694](https://folio-org.atlassian.net/browse/MODLD-694)

--- a/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/controlfield/UpdatedDateMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/controlfield/UpdatedDateMapper.java
@@ -1,0 +1,60 @@
+package org.folio.marc4ld.service.ld2marc.mapper.controlfield;
+
+import static java.time.Instant.ofEpochMilli;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.ObjectUtils.anyNull;
+import static org.folio.marc4ld.util.Constants.TAG_005;
+import static org.folio.marc4ld.util.LdUtil.getWork;
+import static org.folio.marc4ld.util.LdUtil.isInstance;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.folio.ld.dictionary.model.Resource;
+import org.folio.marc4ld.service.ld2marc.mapper.CustomControlFieldsMapper;
+import org.folio.marc4ld.service.ld2marc.resource.field.ControlFieldsBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatedDateMapper implements CustomControlFieldsMapper {
+
+  private static final DateTimeFormatter MARC_UPDATED_DATE_FORMAT = DateTimeFormatter
+    .ofPattern("yyyyMMddHHmmss.0")
+    .withZone(ZoneOffset.UTC);
+
+  @Override
+  public void map(Resource resource, ControlFieldsBuilder controlFieldsBuilder) {
+    if (isInstance(resource)) {
+      var optionalWork = getWork(resource);
+      optionalWork.ifPresentOrElse(work -> {
+          var optionalDate = chooseDate(resource.getUpdatedDate(), work.getUpdatedDate());
+          optionalDate.ifPresent(date -> addUpdatedDateField(date, controlFieldsBuilder));
+        },
+        () -> ofNullable(resource.getUpdatedDate())
+          .ifPresent(date -> addUpdatedDateField(date, controlFieldsBuilder))
+      );
+    }
+  }
+
+  private void addUpdatedDateField(Date date, ControlFieldsBuilder controlFieldsBuilder) {
+    var dateStr = convertDate(date);
+    controlFieldsBuilder.addFieldValue(TAG_005, dateStr, 0, dateStr.length());
+  }
+
+  private String convertDate(Date date) {
+    return MARC_UPDATED_DATE_FORMAT.format(ofEpochMilli(date.getTime()));
+  }
+
+  private Optional<Date> chooseDate(Date instanceDate, Date workDate) {
+    if (anyNull(instanceDate, workDate)) {
+      return Stream.of(instanceDate, workDate)
+        .filter(Objects::nonNull)
+        .findFirst();
+    }
+    return instanceDate.after(workDate) ? of(instanceDate) : of(workDate);
+  }
+}

--- a/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/AbstractClassificationMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/AbstractClassificationMapper.java
@@ -10,7 +10,6 @@ import static org.folio.marc4ld.util.Constants.B;
 import static org.folio.marc4ld.util.LdUtil.getPropertyValue;
 import static org.folio.marc4ld.util.LdUtil.getPropertyValues;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -28,7 +27,6 @@ public abstract class AbstractClassificationMapper implements CustomDataFieldsMa
 
   private static final Set<ResourceTypeDictionary> SUPPORTED_TYPES = Set.of(CLASSIFICATION);
 
-  protected final ObjectMapper objectMapper;
   protected final MarcFactory marcFactory;
 
   private final String tag;

--- a/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/Ld2MarcDdcClassificationMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/Ld2MarcDdcClassificationMapper.java
@@ -18,7 +18,6 @@ import static org.folio.marc4ld.util.Constants.TWO;
 import static org.folio.marc4ld.util.Constants.ZERO;
 import static org.folio.marc4ld.util.LdUtil.getPropertyValue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import org.folio.ld.dictionary.model.Resource;
 import org.folio.ld.dictionary.model.ResourceEdge;
@@ -29,8 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class Ld2MarcDdcClassificationMapper extends AbstractClassificationMapper {
 
-  public Ld2MarcDdcClassificationMapper(ObjectMapper objectMapper, MarcFactory marcFactory) {
-    super(objectMapper, marcFactory, TAG_082, DDC);
+  public Ld2MarcDdcClassificationMapper(MarcFactory marcFactory) {
+    super(marcFactory, TAG_082, DDC);
   }
 
   @Override

--- a/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/Ld2MarcLcClassificationMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/ld2marc/mapper/datafield/classification/Ld2MarcLcClassificationMapper.java
@@ -12,7 +12,6 @@ import static org.folio.marc4ld.util.Constants.ONE;
 import static org.folio.marc4ld.util.Constants.SPACE;
 import static org.folio.marc4ld.util.Constants.ZERO;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.folio.ld.dictionary.model.Resource;
 import org.marc4j.marc.MarcFactory;
 import org.springframework.stereotype.Component;
@@ -20,8 +19,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class Ld2MarcLcClassificationMapper extends AbstractClassificationMapper {
 
-  public Ld2MarcLcClassificationMapper(MarcFactory marcFactory, ObjectMapper objectMapper) {
-    super(objectMapper, marcFactory, TAG_050, LC);
+  public Ld2MarcLcClassificationMapper(MarcFactory marcFactory) {
+    super(marcFactory, TAG_050, LC);
   }
 
   @Override


### PR DESCRIPTION
At present, the logic for including 005 control field is within the `Resource2MarcRecordMapperImpl` class. Purpose of this PR is to create a new class that implements `CustomControlFieldsMapper` for this purpose.

Commit 1 - Create a new class for adding 005 field to marc record
Commit 2 - Code cleanup by removing an unused field  from some classes