### PR TITLE
MODLD-840: fix filmography supp content mapping

### DIFF
--- a/src/main/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/SupplementaryContentMapper.java
+++ b/src/main/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/SupplementaryContentMapper.java
@@ -22,10 +22,15 @@ public class SupplementaryContentMapper extends AbstractCategoryMapper {
   public static final Map<Character, String> CODE_TO_LINK_SUFFIX_MAP = Map.of(
     'b', "bibliography",
     'k', "discography",
+    'q', "film",
+    '1', "index"
+  );
+  private static final Map<Character, String> CODE_TO_TERM_MAP = Map.of(
+    'b', "bibliography",
+    'k', "discography",
     'q', "filmography",
     '1', "index"
   );
-
   private static final Set<Character> SUPPORTED_CODES = Set.of('b', 'k', 'q');
   private static final int INDEX_PRESENT_INDEX = 31;
 
@@ -54,12 +59,12 @@ public class SupplementaryContentMapper extends AbstractCategoryMapper {
 
   @Override
   protected String getTerm(char code) {
-    return getLinkSuffix(code);
+    return CODE_TO_TERM_MAP.get(code);
   }
 
   @Override
   protected String getCode(char code) {
-    return getTerm(code);
+    return CODE_TO_LINK_SUFFIX_MAP.get(code);
   }
 
   @Override

--- a/src/test/java/org/folio/marc4ld/mapper/field008/supplementary/Ld2MarcSupplementaryContentIT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field008/supplementary/Ld2MarcSupplementaryContentIT.java
@@ -66,7 +66,7 @@ class Ld2MarcSupplementaryContentIT {
       Map.of(SUPPLEMENTARY_CONTENT, List.of(
         createCategory("bibliography", "http://id.loc.gov/vocabulary/msupplcont/bibliography", "bibliography",
           categorySet),
-        createCategory("filmography", "http://id.loc.gov/vocabulary/msupplcont/filmography", "filmography",
+        createCategory("film", "http://id.loc.gov/vocabulary/msupplcont/film", "filmography",
           categorySet),
         createCategory("discography", "http://id.loc.gov/vocabulary/msupplcont/discography", "discography",
           categorySet),

--- a/src/test/java/org/folio/marc4ld/mapper/field008/supplementary/Marc2LdSupplementaryContentIT.java
+++ b/src/test/java/org/folio/marc4ld/mapper/field008/supplementary/Marc2LdSupplementaryContentIT.java
@@ -40,8 +40,8 @@ class Marc2LdSupplementaryContentIT extends Marc2LdTestBase {
           ), "bibliography");
         validateEdge(edges.get(1), SUPPLEMENTARY_CONTENT, List.of(CATEGORY),
           Map.of(
-            "http://bibfra.me/vocab/library/code", List.of("filmography"),
-            "http://bibfra.me/vocab/lite/link", List.of("http://id.loc.gov/vocabulary/msupplcont/filmography"),
+            "http://bibfra.me/vocab/library/code", List.of("film"),
+            "http://bibfra.me/vocab/lite/link", List.of("http://id.loc.gov/vocabulary/msupplcont/film"),
             "http://bibfra.me/vocab/library/term", List.of("filmography")
           ), "filmography");
         validateEdge(edges.get(2), SUPPLEMENTARY_CONTENT, List.of(CATEGORY),

--- a/src/test/java/org/folio/marc4ld/mapper/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/marc4ld/mapper/test/MonographTestUtil.java
@@ -628,7 +628,7 @@ public class MonographTestUtil {
       createCategorySet("http://id.loc.gov/vocabulary/millus", "Illustrative Content"));
     var supplementaryContentCategorySet =
       createCategorySet("http://id.loc.gov/vocabulary/msupplcont", "Supplementary Content");
-    var supplementaryContent = createCategory("filmography", "http://id.loc.gov/vocabulary/msupplcont/filmography",
+    var supplementaryContent = createCategory("film", "http://id.loc.gov/vocabulary/msupplcont/film",
       "filmography", supplementaryContentCategorySet);
     var indexSupplementaryContent = createCategory("index", "http://id.loc.gov/vocabulary/msupplcont/index", "index",
       supplementaryContentCategorySet);

--- a/src/test/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/SupplementaryContentMapperTest.java
+++ b/src/test/java/org/folio/marc4ld/service/marc2ld/bib/mapper/custom/SupplementaryContentMapperTest.java
@@ -79,7 +79,7 @@ class SupplementaryContentMapperTest {
   @CsvSource(value = {
     "b, bibliography",
     "k, discography",
-    "q, filmography",
+    "q, film",
     "1, index"
   })
   void getLinkSuffix_shouldReturn_correctSuffix(char code, String expectedSuffix) {
@@ -103,7 +103,7 @@ class SupplementaryContentMapperTest {
   @CsvSource(value = {
     "b, bibliography",
     "k, discography",
-    "q, filmography",
+    "q, film",
     "1, index"
   })
   void getCode_shouldReturn_correctCode(char code, String expectedCode) {


### PR DESCRIPTION
According to https://id.loc.gov/vocabulary/msupplcont/film.html, link should end with "film", while term should end with "filmography"